### PR TITLE
Header menu overlap

### DIFF
--- a/css/parent-theme-modifications-700+.css
+++ b/css/parent-theme-modifications-700+.css
@@ -6,6 +6,7 @@
 /* Style website header area */
 header#site-header {
 	background-size: cover;
+	z-index: 999;
 }
 
 /* Style the toggle-inner container (contains the search and menu icons) */


### PR DESCRIPTION
This should take care of the issue with longer submenus (desktop view) being overlapped by widgets in the homepage/top area and with focus on submenus being lost on hover when they overlap a CTA in the homepage/banner area. Tested in Chrome, Firefox and Edge on Windows. 