### PR TITLE
Fix homepage slideshow: image sizing, navigation, and empty UI elements

### DIFF
--- a/css/slideshow.css
+++ b/css/slideshow.css
@@ -15,6 +15,10 @@
 .gmuj-slide {
 	/*background-position: top center;*/
 	/*background-repeat: no-repeat;*/
+	/* !important is required: the inline `background` shorthand on each slide
+	   resets background-size to `auto`, and only !important can override an
+	   inline declaration. Applied at all widths so slides fill on mobile too. */
+	background-size: cover !important;
 	display: none;
 	cursor: grab;
 }
@@ -172,10 +176,6 @@
 
 	#gmuj-slideshow-wrapper {
 		z-index: 0;
-	}
-
-	.gmuj-slide {
-		background-size: cover !important;
 	}
 
 	.gmuj-slide-nav {

--- a/php/custom-post-type-slideshow.php
+++ b/php/custom-post-type-slideshow.php
@@ -5,6 +5,17 @@
 
 
 /**
+ * Register a custom image size for slideshow slides.
+ * 1920x1080 (16:9), hard cropped so every slide has a consistent aspect ratio.
+ * The slideshow template (template-parts/slideshow.php) requests this 'homepage-slide'
+ * size; without it WordPress falls back to the full-size original.
+ */
+add_action('after_setup_theme', 'gmuj_register_slideshow_image_size');
+function gmuj_register_slideshow_image_size() {
+    add_image_size('homepage-slide', 1920, 1080, true);
+}
+
+/**
  * Register a custom post type for the homepage slider slides
  */
 add_action('init', 'gmuj_register_custom_post_type_slideshow');

--- a/php/custom-scripts.php
+++ b/php/custom-scripts.php
@@ -12,21 +12,34 @@ add_action('wp_enqueue_scripts','gmuj_enqueue_scripts');
 function gmuj_enqueue_scripts() {
 
   // Enqueue swiping jquery library
+  // Depends on jquery; Twenty Twenty does not load jQuery on the front end, so
+  // it must be declared as a dependency or every jQuery call below throws.
   wp_enqueue_script(
     'gmuj_script_swipe', //script name
-    get_theme_file_uri('/js/jquery.touchSwipe.js') //path to script
+    get_theme_file_uri('/js/jquery.touchSwipe.js'), //path to script
+    array('jquery'), //dependencies
+    false, //version
+    true //load in footer
   );
 
   // Enqueue slideshow javascript
   wp_enqueue_script(
     'gmuj_script_slideshow', //script name
-    get_theme_file_uri('/js/slideshow.js') //path to script
+    get_theme_file_uri('/js/slideshow.js'), //path to script
+    array('jquery'), //dependencies
+    false, //version
+    true //load in footer
   );
 
   // Enqueue the slideshow initiation javascript
+  // Runs jQuery(document).ready and .swipe(), so it needs jquery, the swipe
+  // library, and the slideshow functions all loaded first.
   wp_enqueue_script(
     'gmuj_script_slideshow_init', //script name
-    get_theme_file_uri('/js/slideshow-init.js') //path to script
+    get_theme_file_uri('/js/slideshow-init.js'), //path to script
+    array('jquery', 'gmuj_script_swipe', 'gmuj_script_slideshow'), //dependencies
+    false, //version
+    true //load in footer
   );
 
 }

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/jmacario-gmu/gmuj-wordpress-theme-mason-twentytwen
 Author: Mason Web Operations and Services
 Author URI: https://wordpress.gmu.edu
 Description: A custom Mason-styled WordPress child theme based on the official WordPress Twentytwenty theme.
-Version: 1.4.6
+Version: 1.4.7
 Requires at least: 4.7
 Tested up to: 6.6
 Requires PHP: 7.0

--- a/template-parts/slideshow.php
+++ b/template-parts/slideshow.php
@@ -95,18 +95,29 @@ if (count($slides) >= 1) {
 							}
 						?>
 						
+						<?php
+							// Only render the caption strip if it has something to show:
+							// body text and/or a visible CTA button. Prevents an empty
+							// black bar on image-only slides. (The title sits above the
+							// strip and is controlled separately by hide_title.)
+							$slide_content = trim( get_the_content() );
+							$show_cta = !get_post_meta( get_the_ID(), 'gmuj_slide_hide_cta', true );
+							if ( $slide_content !== '' || $show_cta ) {
+						?>
 						<div id="gmuj-slide-body-<?php the_ID(); ?>" class="gmuj-slide-body">
 
 							<div class="gmuj-slide-body-wrapper">
 
+								<?php if ( $slide_content !== '' ) { ?>
 								<div class="gmuj-slide-body-text">
 									<?php the_content(); ?>
 								</div>
+								<?php } ?>
 
 								<!-- slide CTA -->
 								<?php
 									// should we show or hide the cta?
-									if (!get_post_meta(get_the_ID(), 'gmuj_slide_hide_cta', true)) {
+									if ( $show_cta ) {
 										?>
 										<div class="gmuj-slide-cta">
 											<p>
@@ -123,6 +134,7 @@ if (count($slides) >= 1) {
 							</div>
 
 						</div>
+						<?php } // end caption strip ?>
 
 					</div>	
 
@@ -130,10 +142,15 @@ if (count($slides) >= 1) {
 
 		<?php endwhile; else: endif; wp_reset_query(); ?>
 
+	<?php
+		// Only show the previous/next arrows when there is more than one slide
+		if ( $slide_counter > 1 ) {
+	?>
 	<div class="gmuj-slide-nav">
 		<div class="gmuj-slide-nav-previous"><a href="#" onclick="gmuj_slide_back(); return false;">Previous Slide</a></div>
 		<div class="gmuj-slide-nav-next"><a href="#" onclick="gmuj_slide_forward(); return false;">Next Slide</a></div>
 	</div>
+	<?php } ?>
 
 </div>
 


### PR DESCRIPTION
## Summary

Fixes several issues with the homepage slideshow (the `slideshow` custom post type) so that slides display correctly and navigation works, and bumps the theme version to **1.4.7**.

Slides paint the post's **featured image** ("Slide Image") as a CSS background on `.gmuj-slide`, and navigation/auto-advance is driven by jQuery in `js/slideshow.js`. A few problems prevented this from working as intended.

## Changes

### 1. Slides now fill their container (image sizing)
- `background-size: cover` was only applied inside the `@media (min-width: 1000px)` block, so on smaller screens slides rendered at the image's natural size — either too small or cropped at an arbitrary point.
- The inline `background` shorthand printed on each slide resets `background-size` back to `auto`, which can only be overridden by an `!important` rule. A plain stylesheet rule was silently losing the cascade.
- **Fix:** hoisted `background-size: cover !important` to the base `.gmuj-slide` rule so slides fill the container at every screen width.
- Registered a `homepage-slide` image size (1920×1080, hard cropped). The template already requested this size via `wp_get_attachment_image_src( …, 'homepage-slide' )`, but it was never registered, so WordPress fell back to the full-size original. Each slide now draws from a consistent 16:9 source.

### 2. Navigation now works (jQuery dependency)
- The slideshow scripts (`jquery.touchSwipe.js`, `slideshow.js`, `slideshow-init.js`) were enqueued **without declaring `jquery` as a dependency**.
- The Twenty Twenty parent theme does not load jQuery on the front end, so jQuery never loaded. Every arrow click and the auto-advance timer threw `ReferenceError: jQuery is not defined`, leaving the slideshow stuck on the first slide.
- **Fix:** declared the `jquery` dependency (plus inter-script dependencies so they load in the right order) and moved the scripts to the footer.

### 3. Hide empty UI elements
- The caption strip (`.gmuj-slide-body`) was always rendered, leaving an empty black bar on image-only slides. It is now rendered only when a slide has body text and/or a visible CTA. (The title sits above the strip and remains controlled separately by the existing `hide_title` option.)
- The previous/next arrows are now shown only when there is more than one slide.

### 4. Version bump
- `1.4.6` → `1.4.7`.

## Testing

Verified locally with `wp-env` and browser DevTools:
- Computed `background-size` on the active slide resolves to `cover` (previously `auto`).
- jQuery loads on the front end; touchSwipe binds; arrow clicks advance/rewind slides; the auto-advance timer runs.
- Image-only slides render no caption strip; the nav arrows are hidden when only one slide is present.

## Files changed
- `css/slideshow.css`
- `php/custom-post-type-slideshow.php`
- `php/custom-scripts.php`
- `template-parts/slideshow.php`
- `style.css`
